### PR TITLE
replacing primary with backgroundColor, due to subject for deprecation

### DIFF
--- a/movie/lib/presentation/pages/movie_detail_page.dart
+++ b/movie/lib/presentation/pages/movie_detail_page.dart
@@ -235,7 +235,8 @@ class MovieDetailContent extends StatelessWidget {
                       ],
                     ),
                     style: ElevatedButton.styleFrom(
-                      primary: isAddedToWatchlist ? Colors.grey[850] : Colors.white,
+                      backgroundColor:
+                          isAddedToWatchlist ? Colors.grey[850] : Colors.white,
                       minimumSize: Size(
                         MediaQuery.of(context).size.width,
                         42.0,

--- a/movie/lib/presentation/widgets/minimal_detail.dart
+++ b/movie/lib/presentation/widgets/minimal_detail.dart
@@ -153,7 +153,7 @@ class MinimalDetail extends StatelessWidget {
                 ],
               ),
               style: TextButton.styleFrom(
-                primary: Colors.white,
+                backgroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16.0,
                   vertical: 16.0,

--- a/tv/lib/presentation/pages/tv_detail_page.dart
+++ b/tv/lib/presentation/pages/tv_detail_page.dart
@@ -271,7 +271,7 @@ class _TvDetailContentState extends State<TvDetailContent>
                       ],
                     ),
                     style: ElevatedButton.styleFrom(
-                      primary: widget.isAddedToWatchlist
+                      backgroundColor: widget.isAddedToWatchlist
                           ? Colors.grey[850]
                           : Colors.white,
                       minimumSize: Size(

--- a/tv/lib/presentation/widgets/minimal_detail.dart
+++ b/tv/lib/presentation/widgets/minimal_detail.dart
@@ -160,7 +160,7 @@ class MinimalDetail extends StatelessWidget {
                 ],
               ),
               style: TextButton.styleFrom(
-                primary: Colors.white,
+                backgroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16.0,
                   vertical: 16.0,


### PR DESCRIPTION
primary' is deprecated and shouldn't be used. Use backgroundColor instead. This feature was deprecated after v3.1.0